### PR TITLE
호텔 상세 페이지 제작

### DIFF
--- a/src/main/frontend/src/App.js
+++ b/src/main/frontend/src/App.js
@@ -94,7 +94,7 @@ function App() {
 
         {/* 숙소 페이지 */}
         <Route path='/hotels' element={<><Header /><HotelsList /></>} />
-        <Route path='/hotels/details' element={<><Header /><HotelDetails /></>} />
+        <Route path='/hotels/:id' element={<><Header /><HotelDetails /></>} />
 
       </Routes>
     </main>

--- a/src/main/frontend/src/hotels/css/HotelsDetails.css
+++ b/src/main/frontend/src/hotels/css/HotelsDetails.css
@@ -29,10 +29,19 @@
 }
 
 .room-header h2 {
-    font-size: 1rem;
+    font-size: 1.3rem;
     color: #333;
     border-style:none;
     margin: 10px 0;
+}
+
+.hotel-room {
+    border-style: solid;
+    border-color: rgb(97, 97, 97);
+    padding: 15px;
+    margin-bottom: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
   /* 객실 정보 항목 */
@@ -40,12 +49,9 @@
     display: flex;  /* Flexbox로 설정 */
     justify-content: space-between;  /* 각 p를 공간에 맞게 배치 */
     gap: 10px;  /* 각 p 사이에 간격 추가 */
-    border-style: solid;
-    border-color: rgb(97, 97, 97);
     padding: 15px;
     margin-bottom: 20px;
     border-radius: 8px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
 .room-info .room p {
@@ -86,4 +92,29 @@
     border: 0;
   }
   
-  
+  .room-card {
+    border-radius: 8px;
+    overflow: hidden;
+    display: flex; /* 플렉스 박스 설정 */
+    flex-direction: row; /* 가로 방향 정렬 */
+    justify-content: center; /* 가로 중앙 정렬 */
+    align-items: center; /* 세로 중앙 정렬 */
+    gap: 10px; /* 이미지 간격 추가 */
+    height: 170px; /* 컨테이너 높이 설정 (필요시 수정) */
+}
+
+.room-image {
+    width: 170px; /* 이미지 너비 */
+    height: 170px; /* 이미지 높이 */
+    object-fit: cover; /* 이미지 비율 유지 */
+    padding: 10px;
+}
+
+.thum-img img {
+    background-color: #ffffff;
+    margin-top: 20px;
+    width: 100%;
+    height: 300px;
+    border-radius: 10px;
+    border: 0;
+}

--- a/src/main/frontend/src/hotels/js/HotelsDetails.js
+++ b/src/main/frontend/src/hotels/js/HotelsDetails.js
@@ -1,50 +1,85 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import { format } from "date-fns";
 import { useParams } from 'react-router-dom';
 import "../css/HotelsDetails.css";
 
+function formatTime(dateString) {
+    if (!dateString) return "날짜 정보 없음"; // dateString이 null/undefined/빈 문자열일 경우 처리
+    const date = new Date(dateString);
+
+    if (isNaN(date.getTime())) {
+        // 유효하지 않은 날짜 포맷 처리
+        return "잘못된 날짜";
+    }
+
+    return format(date, "yyyy-MM-dd h:mm:ss a"); // 유효한 경우 날짜 포맷팅
+}
+
+
 const HotelDetails = () => {
-    const roomData = [
-        {
-            name: '아랫방',
-            size: '5',
-            bed: '2',
-            type: '더블',
-            price: '₩135,000',
-            amenities: ['인터넷', '에어컨', 'TV'],
-        },
-        {
-            name: '사랑방',
-            size: '4',
-            bed: '1',
-            type: '싱글',
-            price: '₩85,000',
-            amenities: ['냉장고', '소파', 'PC'],
-        },
-        // 더 많은 객실 데이터를 여기에 추가
-    ];
+    const baseUrl = "http://localhost:8080";
+    const [data, setData] = useState([]);
+    const { id } = useParams();
+    
+    useEffect(() => {
+        axios.get(baseUrl + `/hotels/${id}`)
+            .then((res) => {
+                const item = res.data;
+                setData(item);
+            })
+            .catch((error) => {
+                console.error('질문 데이터 오류:', error);
+            });
+    }, [id]);
   
     return (
         <div className="hotel-detail">
             <div className="hotel-content">
                 <div className="room-info">
                     <div className="room-header">
-                        <h1>한옥1957</h1>
+                        <h1>{data.title}</h1>  
                         <h2>객실 정보 ___</h2>
                     </div>
                     <div>
-                    {roomData.map((room, index) => (
-                        <div className="room" key={index}>
-                            <h4>{room.name}-</h4>
+                    {data.rooms && data.rooms.map((room, index) => (
+                        <div className="hotel-room" key={index}>
+                            <h3>{room.roomtitle}-</h3>
+                            <div className="room">
                             <div className='room-section'>
-                                <p>객실 크기(평): {room.size}</p>
-                                <p>침대: {room.bed}</p>
-                                <p>객실 타입: {room.type}</p>
+                                <p>객실 크기(평): {room.roomsize1}</p>
+                                <p>객실수: {room.roomcount}</p>
+                                <p>기존 인원: {room.roombasecount}</p>
+                                <p>최대 인원: {room.roommaxcount}</p>
+                                <p>비수기 주중: {room.roomoffseasonminfee1}</p>
+                                <p>비수기 주말: {room.roomoffseasonminfee2}</p>
+                                <p>객실 소개: {room.roomintro}</p>
                             </div>
                             <div className='room-section'>
-                                <p>최대 인원: {room.bed}</p>
-                                <p>비수기 주중: {room.price}</p>
-                                <p>목욕 시설: {room.amenities.join(', ')}</p>
+                                <p>목욕 시설: {room.roombathfacility}</p>
+                                <p>욕조: {room.roombath}</p>
+                                <p>홈시어터: {room.roomhometheater}</p>
+                                <p>에어컨: {room.roomaircondition}</p>
+                                <p>TV: {room.roomtv}</p>
+                                <p>PC: {room.roompc}</p>
+                                <p>케이블 설치: {room.roomcable}</p>
+                            </div>
+                            <div className='room-section'>
+                                <p>인터넷: {room.roominternet}</p>
+                                <p>냉장고: {room.roomrefrigerator}</p>
+                                <p>세먼도구: {room.roomtoiletries}</p>
+                                <p>소파: {room.roomsofa}</p>
+                                <p>취사용품: {room.roomcook}</p>
+                                <p>테이블: {room.roomtable}</p>
+                                <p>드라이기: {room.roomhairdryer}</p>
+                            </div>
+                            </div>
+                            <div className='room-card'>
+                                {room.roomimg1 ? <img className='room-image' src={room.roomimg1} alt="" /> : "이미지가 존재하지 않습니다" }
+                                {room.roomimg2 ? <img className='room-image' src={room.roomimg2} alt="" /> : "" }
+                                {room.roomimg3 ? <img className='room-image' src={room.roomimg3} alt="" /> : "" }
+                                {room.roomimg4 ? <img className='room-image' src={room.roomimg4} alt="" /> : "" }
+                                {room.roomimg5 ? <img className='room-image' src={room.roomimg5} alt="" /> : "" }
                             </div>
                         </div>
                     ))}
@@ -53,8 +88,17 @@ const HotelDetails = () => {
     
                 <div className="hotel-info">
                     <div className="hotel-sinfo">
-                        <p>숙소 주소, 연락처 등 상세 정보를 여기에 입력하세요.</p>
+                        <p>최초 등록일 : {formatTime(data.createDate)} </p>
+                        <p>최종 수정일 : {formatTime(data.modifiedDate)} </p> 
+                        <p>연락처 : {data.tel} </p>
+                        <p>주소 : {data.addr1} {data.addr2}</p>
                     </div>
+                    <div className="thum-img">{data.firstimage2 ? (
+                                <img src={data.firstimage2} alt="" />
+                            ) : (
+                                <img src={`${process.env.PUBLIC_URL}/Image/noimg.png`} alt="no_img" width="100%" height="100%" />
+                            )}</div>
+                
                     <div className="map">
                         <iframe
                             src="https://www.google.com/maps/embed?pb=..."

--- a/src/main/frontend/src/hotels/js/HotelsList.js
+++ b/src/main/frontend/src/hotels/js/HotelsList.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import '../css/HotelsList.css';
 import { format } from "date-fns";
 import axios from "axios";
+import { useNavigate } from "react-router-dom";
 
 function formatTime(dateString) {
     const date = new Date(dateString);
@@ -16,6 +17,11 @@ function HotelsList() {
         putSpringData();
     }, []);
 
+      const navigate = useNavigate();
+    
+      const detailsClick = (id) => {
+        navigate(`/hotels/${id}`);
+      };
     
     async function putSpringData() {
         await axios
@@ -82,7 +88,7 @@ function HotelsList() {
             {data.length > 0 ? (
                 data.map((datas, index) => (
                     <div key={index} className="hotel-card">
-                        <div className="hotel-image">
+                        <div className="hotel-image" onClick={() => detailsClick(datas.id)}>
                             {datas.thumbnail ? (
                                 <img src={datas.thumbnail} alt="thumbnail" width="100%" height="100%" />
                             ) : (

--- a/src/main/java/kr/kro/hereinkorea/domain/hotels/controller/HotelsController.java
+++ b/src/main/java/kr/kro/hereinkorea/domain/hotels/controller/HotelsController.java
@@ -8,9 +8,9 @@ import kr.kro.hereinkorea.global.common.dto.PageRequestDTO;
 import kr.kro.hereinkorea.global.common.dto.PageResultDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/hotels")
@@ -47,5 +47,12 @@ public class HotelsController {
     @GetMapping("/list")
     public PageResultDTO<HotelsDTO, Object[]> list(PageRequestDTO requestDTO){
         return hotelsService.getList(requestDTO);
+    }
+
+    @GetMapping("/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity findHotelsById(@PathVariable("id") Long id){
+        HotelsDTO hotelsDTO = hotelsService.get(id);
+        return ResponseEntity.ok(hotelsDTO);
     }
 }

--- a/src/main/java/kr/kro/hereinkorea/domain/hotels/dto/HotelsDTO.java
+++ b/src/main/java/kr/kro/hereinkorea/domain/hotels/dto/HotelsDTO.java
@@ -3,6 +3,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 @AllArgsConstructor
@@ -23,5 +24,7 @@ public class HotelsDTO {
     private String firstimage2;
     private LocalDateTime createDate;
     private LocalDateTime modifiedDate;
+
+    private List<RoomDTO> rooms;
 }
 

--- a/src/main/java/kr/kro/hereinkorea/domain/hotels/dto/RoomDTO.java
+++ b/src/main/java/kr/kro/hereinkorea/domain/hotels/dto/RoomDTO.java
@@ -10,7 +10,6 @@ import lombok.*;
 @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RoomDTO {
-
     private Long id;
     private Long contentid;
     private String roomtitle; // 객실 명칭

--- a/src/main/java/kr/kro/hereinkorea/domain/hotels/entity/HotelsEntity.java
+++ b/src/main/java/kr/kro/hereinkorea/domain/hotels/entity/HotelsEntity.java
@@ -34,4 +34,5 @@ public class HotelsEntity extends BaseEntity {
 
     @Column(length = 20)
     private String tel;
+
 }

--- a/src/main/java/kr/kro/hereinkorea/domain/hotels/repository/HotelsRepository.java
+++ b/src/main/java/kr/kro/hereinkorea/domain/hotels/repository/HotelsRepository.java
@@ -26,7 +26,7 @@ public interface HotelsRepository extends JpaRepository<HotelsEntity, Long> {
                     "FROM HotelsEntity h " +
                     "LEFT JOIN HotelsImgEntity i ON i.hotels = h " +
                     "LEFT JOIN RoomEntity r ON r.hotels = h " +
-                    "WHERE h.id = :id"
+                    "WHERE h.contentid = :id"
     )
     List<Object[]> getHotelsById(@Param("id") Long id);
 }

--- a/src/main/java/kr/kro/hereinkorea/domain/hotels/repository/HotelsRepository.java
+++ b/src/main/java/kr/kro/hereinkorea/domain/hotels/repository/HotelsRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface HotelsRepository extends JpaRepository<HotelsEntity, Long> {
 
@@ -16,4 +19,14 @@ public interface HotelsRepository extends JpaRepository<HotelsEntity, Long> {
             countQuery = "SELECT COUNT(h) " +
                     "FROM HotelsEntity h ")
     Page<Object[]> getHotelsCount(Pageable pageable);
+
+
+    @Query(
+            value = "SELECT h, i, r " +
+                    "FROM HotelsEntity h " +
+                    "LEFT JOIN HotelsImgEntity i ON i.hotels = h " +
+                    "LEFT JOIN RoomEntity r ON r.hotels = h " +
+                    "WHERE h.id = :id"
+    )
+    List<Object[]> getHotelsById(@Param("id") Long id);
 }

--- a/src/main/java/kr/kro/hereinkorea/domain/hotels/service/HotelsService.java
+++ b/src/main/java/kr/kro/hereinkorea/domain/hotels/service/HotelsService.java
@@ -7,6 +7,9 @@ import kr.kro.hereinkorea.domain.hotels.entity.HotelsEntity;
 import kr.kro.hereinkorea.domain.hotels.entity.HotelsImgEntity;
 import kr.kro.hereinkorea.domain.hotels.entity.RoomEntity;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public interface HotelsService {
 
     default RoomEntity dtoToEntity(RoomDTO dto){
@@ -45,40 +48,6 @@ public interface HotelsService {
                 .build();
     }
 
-    default RoomDTO entityToDTO(RoomEntity entity) {
-        return RoomDTO.builder()
-                .id(entity.getId())
-                .contentid(entity.getHotels().getContentid())
-                .roomtitle(entity.getRoomtitle())
-                .roomsize1(entity.getRoomsize1())
-                .roomcount(entity.getRoomcount())
-                .roombasecount(entity.getRoombasecount())
-                .roommaxcount(entity.getRoommaxcount())
-                .roomoffseasonminfee1(entity.getRoomoffseasonminfee1())
-                .roomoffseasonminfee2(entity.getRoomoffseasonminfee2())
-                .roomintro(entity.getRoomintro())
-                .roombathfacility(entity.getRoombathfacility())
-                .roombath(entity.getRoombath())
-                .roomhometheater(entity.getRoomhometheater())
-                .roomaircondition(entity.getRoomaircondition())
-                .roomtv(entity.getRoomtv())
-                .roompc(entity.getRoompc())
-                .roomcable(entity.getRoomcable())
-                .roominternet(entity.getRoominternet())
-                .roomrefrigerator(entity.getRoomrefrigerator())
-                .roomtoiletries(entity.getRoomtoiletries())
-                .roomsofa(entity.getRoomsofa())
-                .roomcook(entity.getRoomcook())
-                .roomtable(entity.getRoomtable())
-                .roomhairdryer(entity.getRoomhairdryer())
-                .roomimg1(entity.getRoomimg1())
-                .roomimg2(entity.getRoomimg2())
-                .roomimg3(entity.getRoomimg3())
-                .roomimg4(entity.getRoomimg4())
-                .roomimg5(entity.getRoomimg5())
-                .build();
-    }
-
     default HotelsDTO entityToDTO(HotelsEntity hotels, HotelsImgEntity img){
         return HotelsDTO.builder()
                 .contentid(hotels.getContentid())
@@ -92,6 +61,56 @@ public interface HotelsService {
                 .createDate(hotels.getCreatedDate())
                 .modifiedDate(hotels.getModifiedDate())
                 .firstimage2(img != null ? img.getFirstimage() : null)
+                .build();
+    }
+
+    default HotelsDTO entityToDTO(HotelsEntity hotels, HotelsImgEntity img, List<RoomEntity> rooms) {
+        List<RoomDTO> roomDTOs = rooms.stream()
+                .map(room -> RoomDTO.builder()
+                        .id(room.getId())
+                        .roomtitle(room.getRoomtitle())
+                        .roomsize1(room.getRoomsize1())
+                        .roomcount(room.getRoomcount())
+                        .roombasecount(room.getRoombasecount())
+                        .roommaxcount(room.getRoommaxcount())
+                        .roomoffseasonminfee1(room.getRoomoffseasonminfee1())
+                        .roomoffseasonminfee2(room.getRoomoffseasonminfee2())
+                        .roomintro(room.getRoomintro())
+                        .roombathfacility(room.getRoombathfacility())
+                        .roombath(room.getRoombath())
+                        .roomhometheater(room.getRoomhometheater())
+                        .roomaircondition(room.getRoomaircondition())
+                        .roomtv(room.getRoomtv())
+                        .roompc(room.getRoompc())
+                        .roomcable(room.getRoomcable())
+                        .roominternet(room.getRoominternet())
+                        .roomrefrigerator(room.getRoomrefrigerator())
+                        .roomtoiletries(room.getRoomtoiletries())
+                        .roomsofa(room.getRoomsofa())
+                        .roomcook(room.getRoomcook())
+                        .roomtable(room.getRoomtable())
+                        .roomhairdryer(room.getRoomhairdryer())
+                        .roomimg1(room.getRoomimg1())
+                        .roomimg2(room.getRoomimg2())
+                        .roomimg3(room.getRoomimg3())
+                        .roomimg4(room.getRoomimg4())
+                        .roomimg5(room.getRoomimg5())
+                        .build())
+                .collect(Collectors.toList());
+
+        return HotelsDTO.builder()
+                .contentid(hotels.getContentid())
+                .title(hotels.getTitle())
+                .addr1(hotels.getAddr1())
+                .addr2(hotels.getAddr2())
+                .areacode(hotels.getAreacode())
+                .mapx(hotels.getMapx())
+                .mapy(hotels.getMapy())
+                .tel(hotels.getTel())
+                .createDate(hotels.getCreatedDate())
+                .modifiedDate(hotels.getModifiedDate())
+                .firstimage2(img != null ? img.getFirstimage() : null)
+                .rooms(roomDTOs) // Room 정보 추가
                 .build();
     }
 

--- a/src/main/java/kr/kro/hereinkorea/domain/hotels/service/HotelsServiceImpl.java
+++ b/src/main/java/kr/kro/hereinkorea/domain/hotels/service/HotelsServiceImpl.java
@@ -3,6 +3,7 @@ package kr.kro.hereinkorea.domain.hotels.service;
 import kr.kro.hereinkorea.domain.hotels.dto.HotelsDTO;
 import kr.kro.hereinkorea.domain.hotels.entity.HotelsEntity;
 import kr.kro.hereinkorea.domain.hotels.entity.HotelsImgEntity;
+import kr.kro.hereinkorea.domain.hotels.entity.RoomEntity;
 import kr.kro.hereinkorea.domain.hotels.repository.HotelsRepository;
 import kr.kro.hereinkorea.global.common.dto.PageRequestDTO;
 import kr.kro.hereinkorea.global.common.dto.PageResultDTO;
@@ -12,6 +13,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -29,5 +34,23 @@ public class HotelsServiceImpl implements HotelsService{
         return new PageResultDTO<HotelsDTO, Object[]>(result,
                 en -> entityToDTO((HotelsEntity) en[0], (HotelsImgEntity)en[1])
         );
+    }
+
+    public HotelsDTO get(Long id) {
+        List<Object[]> results = hotelsRepository.getHotelsById(id);
+
+        if (results.isEmpty()) {
+            throw new RuntimeException("호텔 정보를 찾을 수 없습니다.");
+        }
+
+        HotelsEntity hotels = (HotelsEntity) results.get(0)[0];
+        HotelsImgEntity img = (HotelsImgEntity) results.get(0)[1];
+
+        List<RoomEntity> rooms = results.stream()
+                .map(result -> (RoomEntity) result[2])
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        return entityToDTO(hotels, img, rooms);
     }
 }


### PR DESCRIPTION
호텔 상세 페이지 제작
-객실 데이터 api에서 추출 및 db 테이블에 저장(HotelsEntity와는 N:1 관계)
-호텔 전체 리스트에서 사진을 클릭하면 상세 페이지로 이동(이때 contentid값을 전달함)
-contentid로 호텔 정보와 객실 정보(list)를 받고 front에서 출력
-front의 지도는 임시 데이터 추후 지도가 추가되면 업데이트 예정
![image](https://github.com/user-attachments/assets/60751256-8b94-4720-9479-04f38ab5231e)
